### PR TITLE
fix: 解决适配 rimetool 的部分问题

### DIFF
--- a/double_pinyin_flypy.schema.yaml
+++ b/double_pinyin_flypy.schema.yaml
@@ -218,7 +218,7 @@ translator:
     - xform/([nl])v/$1ü/
     - xform/ü/v/  # ü 显示为 v
   initial_quality: 1.2
-  enable_user_dict: false
+  enable_user_dict: true         # 开启用户词典，根据用户输入调频（默认开启，此处再次声明）
 
 melt_eng:
   dictionary: melt_eng           # 英文词典

--- a/rime_mint.schema.yaml
+++ b/rime_mint.schema.yaml
@@ -151,7 +151,7 @@ translator:
     - xform/([nl])ue/$1üe/
     - xform/([jqxy])v/$1u/
   initial_quality: 1.2
-  enable_user_dict: false
+  enable_user_dict: true         # 开启用户词典，根据用户输入调频（默认开启，此处再次声明）
 
 melt_eng:
   dictionary: melt_eng           # 英文词典

--- a/rime_mint_flypy.schema.yaml
+++ b/rime_mint_flypy.schema.yaml
@@ -156,6 +156,7 @@ translator:
     - xform/([nl])ue/$1üe/
     - xform/([jqxy])v/$1u/
   initial_quality: 1.2
+  enable_user_dict: true         # 开启用户词典，根据用户输入调频（默认开启，此处再次声明）
 
 melt_eng:
   dictionary: melt_eng           # 英文词典

--- a/terra_pinyin.schema.yaml
+++ b/terra_pinyin.schema.yaml
@@ -160,7 +160,6 @@ speller:
 translator:
   dictionary: terra_pinyin
   initial_quality: 1.2
-  enable_user_dict: false
   spelling_hints: 3  # ～字以內候選標註完整帶調拼音
   preedit_format:
     - xform/([nl])v/$1ü/
@@ -224,6 +223,7 @@ translator:
     - xform/([nljqxy])v/$1ü/
     - xform/eh[0-5]?/ê/
     - xform/([a-z]+)[0-5]/$1/
+  enable_user_dict: true         # 开启用户词典，根据用户输入调频（默认开启，此处再次声明）
 
 custom_phrase:
   dictionary: ""

--- a/wubi86_jidian.schema.yaml
+++ b/wubi86_jidian.schema.yaml
@@ -20,13 +20,16 @@ schema:
 switches:
   - name: ascii_mode
     states: [ 中文, 英文 ]
+    reset: 0
   - name: emoji_suggestion
-    reset: 1
     states: [ "😣️","😁️"]
+    reset: 1
   - name: full_shape
     states: [ 半角, 全角 ]
+    reset: 0
   - name: transcription
     states: [ 简体 , 繁体 ]
+    reset: 0
   - name: ascii_punct
     states: [ "。，", "．，" ]
     reset: 0
@@ -130,6 +133,7 @@ translator:
   encode_commit_history: false          # 是否对已上屏词自动成词（仅 table_translator 有效）
   disable_user_dict_for_patterns:   # 对于以下模式禁用用户词典
     - "^z.*$"                       # 以字母"z"开头的任意字符串
+  enable_user_dict: false           # 关闭用户词典，根据用户输入调频（默认开启，形码本身字重低或没有，理论上不需要调频）
 
 # 英文输入
 melt_eng:

--- a/wubi98_mint.schema.yaml
+++ b/wubi98_mint.schema.yaml
@@ -11,15 +11,16 @@ schema:
     - 加入了五笔小筑的部分词库
     - 部分码表源自 yanhuacuo
   dependencies:
-    - melt_eng
-    - rime_mint
+    - melt_eng            # 英文方案
+    - rime_mint           # 薄荷拼音
+
 switches:
   - name: ascii_mode
     reset: 0
     states: [ 中文, 英文 ]
   - name: emoji_suggestion
     states: [ "😣️","😁️"]
-    reset: 0
+    reset: 1
   - name: full_shape
     states: [ 半角, 全角 ]
     reset: 0
@@ -29,6 +30,7 @@ switches:
   - name: ascii_punct
     states: [ 。，, ．， ]
     reset: 0
+
 engine:
   processors:
     - ascii_composer
@@ -42,36 +44,52 @@ engine:
   segmentors:
     - ascii_segmentor
     - matcher
-    - affix_segmentor@rime_mint
+    - affix_segmentor@rime_mint                # 拼音
     - abc_segmentor
     - punct_segmentor
     - fallback_segmentor
   translators:
     - punct_translator
     - script_translator
-    - lua_translator@*mint_date_time_translator
-    - lua_translator@*number_translator
-    - lua_translator@*chineseLunarCalendar_translator
-    - table_translator@melt_eng
-    - reverse_lookup_translator@rime_mint
-    - lua_translator@*force_gc
+    - lua_translator@*mint_date_time_translator          # 时间、日期、星期、月份
+    - lua_translator@*number_translator                  # 金额大小写
+    - lua_translator@*chineseLunarCalendar_translator    # 农历
+    - table_translator@melt_eng                          # 英文输入（作为子翻译器，优先级需要比原生的低）
+    - reverse_lookup_translator@rime_mint                # 反查薄荷拼音
+    - lua_translator@*force_gc                           # 暴力GC，尝试解决小狼毫长期使用的卡顿
   filters:
-    - lua_filter@*autocap_filter
-    - simplifier@emoji_suggestion
-    - lua_filter@*autocap_filter
-    - simplifier@transcription_cc
-    - lua_filter@*reduce_english_filter
-    - uniquifier
+    - lua_filter@*autocap_filter              # 英文自动大写
+    - simplifier@emoji_suggestion             # Emoji
+    - lua_filter@*autocap_filter              # 英文自动大写
+    - simplifier@transcription_cc             # 简繁切换
+    - lua_filter@*reduce_english_filter       # 降低部分英语单词在候选项的位置
+    - uniquifier                              # 去重
+
+# 简繁切换
 transcription_cc:
   option_name: transcription
-  opencc_config: s2t.json
-  tips: none
-  excluded_types: [ reverse_lookup ]
+  opencc_config: s2t.json             # s2t.json | s2hk.json | s2tw.json | s2twp.json
+  tips: none                          # 转换提示: all 都显示 | char 仅单字显示 | none 不显示。
+  excluded_types: [ reverse_lookup ]  # 不转换反查（两分拼字）的内容
+
+# Emoji模块
 emoji_suggestion:
   opencc_config: emoji.json
   option_name: emoji_suggestion
   tips: all
   inherit_comment: false
+
+
+# Lua 配置: 降低部分英语单词在候选项的位置。
+# 详细介绍 https://dvel.me/posts/make-rime-en-better/#短单词置顶的问题
+# 正常情况： 输入 rug 得到 「1.rug 2.如果 …… 」
+# 降低之后： 输入 rug 得到 「1.如果 2.rug …… 」
+# 几种模式：
+# all     使用 reduce_english_filter 自带的降频词库（降低所有 3~4 位长度、前 2~3 位是完整拼音、最后一位是声母的单词）
+# none    不降低任何单词，相当于没有启用这个 Lua
+# custom  自定义，只降低 words 里的
+# 『留白』 不设置该选项，使用 reduce_english_filter 内全局设置内容
+# （匹配的是编码，不是单词）
 reduce_english_filter:
   mode: all
   idx: 2
@@ -93,28 +111,39 @@ reduce_english_filter:
   tad, tail, taj, tar, tax, tec, ted, tel, ter, tex, tic, tied, tier, ties, tim, tin, tit, tour, tout, tum,
   wag, wand, womens, wap, wax, weir, won,
   yan, yen]
+
+# 中国农历配置
 chineseLunarCalendar_translator: lunar
+
 translator:
   dictionary: wubi98_mint
   db_class: tabledb
-  initial_quality: 1.2
-  enable_charset_filter: false
-  enable_sentence: false
+  initial_quality: 1.2                  # 初始质量为1.2
+  enable_charset_filter: false          # 开启字符集过滤
+  enable_sentence: false                # 句子输入模式
   enable_encoder: false
   encode_commit_history: false
-  max_phrase_length: 4
-  enable_completion: false
-  enable_user_dict: false
+  enable_completion: false              # 是否显示编码未输入完整的词条
   disable_user_dict_for_patterns:
     - "^z.*$"
+  enable_user_dict: false           # 关闭用户词典，根据用户输入调频（默认开启，形码本身字重低或没有，理论上不需要调频）
+
+# 英文输入
 melt_eng:
-  dictionary: melt_eng
-  enable_sentence: false
-  enable_completion: false
+  dictionary: melt_eng           # 英文词典
+  enable_sentence: false         # 关闭自动造句
+  enable_completion: false       # 关闭自动提示
   initial_quality: 0.8
+
 speller:
+  # 为了兼容 英文混输，取消自动上屏
+  # max_code_length: 4                    # 四码上屏
+  # auto_select: true                     # 四码唯一时，自动上屏
+  # auto_clear: max_length                # 空码时自动清空
+  # 如果不想让什么标点直接上屏，可以加在 alphabet，或者编辑标点符号为两个及以上的映射
   alphabet: zyxwvutsrqponmlkjihgfedcbaZYXWVUTSRQPONMLKJIHGFEDCBA
-  delimiter: " `"
+  delimiter: " `"  # 第一位<空格>是拼音之间的分隔符；第二位<'>表示可以手动输入单引号来分割拼音。
+
 rime_mint:
   tag: rime_mint
   dictionary: rime_mint
@@ -122,11 +151,20 @@ rime_mint:
   enable_completion: true
   prefix: "Up"
   tips: 〔拼音〕
+
+# 反查设置
 reverse_lookup:
   tags: [rime_mint]
   overwrite_comment: true
+
+# 输入的编码同时进行拼音反查，实现五笔与拼音的混输
+# abc_segmentor:
+#  extra_tags:
+#    - rime_mint
+
 punctuator:
-  import_preset: symbols
+  import_preset: default
+  # 定义部分半角字符
   half_shape:
       "#": "#"
       "*": "*"
@@ -144,6 +182,8 @@ punctuator:
       "$": ["¥", "$", "€", "£", "¢", "¤"]
       "<": ["《", "〈", "«", "<"]
       ">": ["》", "〉", "»", ">"]
+
+# 反查映射
 recognizer:
   import_preset: default
   patterns:
@@ -151,9 +191,11 @@ recognizer:
     punct: "^/([0-9]0?|[a-z]+)$"
     email: "^[A-Za-z][-_.0-9A-Za-z]*@.*$"
     rime_mint: "^Up[a-z]*'?$"
-    rmb: "^R[0-9]+[.]?[0-9]*"
-    gregorian_to_lunar: "^N[0-9]{1,8}"
-    uppercase: ""
+    rmb: "^R[0-9]+[.]?[0-9]*"        # 响应 lua_translator@number_translator 脚本将自动获取第 2 个字符作为触发前缀
+    gregorian_to_lunar: "^N[0-9]{1,8}"  # 响应 lua_translator@Chinese_lunar_calendar 公历转农历，输入 N20240115 得到「二〇二四年腊月初五」，脚本将自动获取第 2 个字符作为触发前缀
+    uppercase: ""  # 覆写默认的 uppercase 使其可以在输入大写后，输入数字
+
+
 key_binder:
   import_preset: default
   bindings:
@@ -192,4 +234,5 @@ key_binder:
     - { when: always, accept: Shift+space, toggle: full_shape }
     - { when: always, accept: Control+period, toggle: ascii_punct }
 menu:
+  # 候选词个数
   page_size: 6


### PR DESCRIPTION
- 部分方案的 switch reset 没有默认值；
- 修复适配过程中误关闭部分方案的用户词典，现在方案的用户词典默认状态由 default.yaml 和 default.custom.yaml 定义全局，方案内部根据方案需要，重写默认状态