### PR TITLE
辅助码提示保留原有comment内容

### DIFF
--- a/lua/auxCode_filter.lua
+++ b/lua/auxCode_filter.lua
@@ -245,11 +245,11 @@ function AuxFilter.func(input, env)
                         originalCand.comment .. shadowComment .. '(' .. codeComment .. ')')
                 elseif env.show_aux_notice == "trigger" then
                     if string.find(inputCode,env.trigger_key_string) then
-                        cand.comment = '(' .. codeComment .. ')'
+                        cand.comment = cand.comment .. '(' .. codeComment .. ')'
                     end
                 else
                     -- 其他情况直接给注释添加辅助代码
-                    cand.comment = '(' .. codeComment .. ')'
+                    cand.comment = cand.comment .. '(' .. codeComment .. ')'
                 end
             end
 


### PR DESCRIPTION
使用〔笔画〕拆字时，comment 中拼音被覆盖

预期：

![image](https://github.com/user-attachments/assets/a4c8827e-bba8-4287-99c4-a950998d038e)

现状：

![image](https://github.com/user-attachments/assets/42d16b21-3777-4c99-a2ef-bc551bab77a9)

