### PR TITLE
fix: 修复注释中的错字

### DIFF
--- a/rime_mint.dict.yaml
+++ b/rime_mint.dict.yaml
@@ -12,6 +12,6 @@ import_tables:
   - dicts/rime_ice.ext           # 雾凇拼音 扩展词库
   - dicts/other_kaomoji          # 颜文字表情（按`VV`呼出)
   - dicts/rime_ice.others        # 雾凇拼音 others词库（用于自动纠错）
-  # 20240608 Emoji完全交友OpenCC，不再使用字典作为补充
+  # 20240608 Emoji完全交由OpenCC，不再使用字典作为补充
   # - dicts/other_emoji            # Emoji(仅仅作为补充，实际使用一般是OpenCC生效)
 ...

--- a/terra_pinyin.dict.yaml
+++ b/terra_pinyin.dict.yaml
@@ -10,6 +10,6 @@ import_tables:
   - dicts/terra_rime_ice.base    # 使用Python转义的雾凇拼音base
   - dicts/terra_rime_ice.ext     # 使用Python转义的雾凇拼音ext
   - dicts/other_kaomoji          # 颜文字表情（按`vv`呼出)
-  # 20240608 Emoji完全交友OpenCC，不再使用字典作为补充
+  # 20240608 Emoji完全交由OpenCC，不再使用字典作为补充
   # - dicts/other_emoji            # Emoji(仅仅作为补充，实际使用一般是OpenCC生效)
 ...


### PR DESCRIPTION
修复了 rime_mint.dict.yaml 和 terra_pinyin.dict.yaml 注释中的错误拼写