### PR TITLE
git 忽略同步目录

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ installation.yaml
 build
 *.userdb
 
+# 同步目录
+sync/
+
 # 自定义文件
 *.custom.yaml
 


### PR DESCRIPTION
在 Linux 下使用时, 只要打开过仓库中原有的配置文件, 就会在 `sync/` 目录下生成一个同步文件, 从而被 git 识别到作出了更改, 对从远端拉取更新不是很方便. 因此提议在 `.gitignore` 中忽略这个目录.