### PR TITLE
fixes: 张居正-修复形如“rfg”识别为“reng”的问题

### DIFF
--- a/rime_mint_flypy.schema.yaml
+++ b/rime_mint_flypy.schema.yaml
@@ -305,117 +305,117 @@ speller:
     # 张居正方案（替换原方案小鹤双拼适配）
     
       # 需要特殊处理避免歧义的韵母
-    - derive/([bcdfghklmnprstwyz])(ang)/$1h
-    - derive/(ch)(ang)/ih
-    - derive/(sh)(ang)/uh
-    - derive/(zh)(ang)/vh
+    - derive/^([bcdfghklmnprstwyz])(ang)$/$1h
+    - derive/^(ch)(ang)$/ih
+    - derive/^(sh)(ang)$/uh
+    - derive/^(zh)(ang)$/vh
 
-    - derive/([cdghklnrstyz])(ong)/$1s
-    - derive/(ch)(ong)/is
-    - derive/(zh)(ong)/vs
+    - derive/^([cdghklnrstyz])(ong)$/$1s
+    - derive/^(ch)(ong)$/is
+    - derive/^(zh)(ong)$/vs
 
-    - derive/([bcdghklmnpstwz])(ai)/$1d
-    - derive/(ch)(ai)/id
-    - derive/(sh)(ai)/ud
-    - derive/(zh)(ai)/vd
+    - derive/^([bcdghklmnpstwz])(ai)$/$1d
+    - derive/^(ch)(ai)$/id
+    - derive/^(sh)(ai)$/ud
+    - derive/^(zh)(ai)$/vd
 
-    - derive/([bcdghklmnprstyz])(ao)/$1c
-    - derive/(ch)(ao)/ic
-    - derive/(sh)(ao)/uc
-    - derive/(zh)(ao)/vc
+    - derive/^([bcdghklmnprstyz])(ao)$/$1c
+    - derive/^(ch)(ao)$/ic
+    - derive/^(sh)(ao)$/uc
+    - derive/^(zh)(ao)$/vc
 
-    - derive/([bcdfghklmnprstwyz])(an)/$1j
-    - derive/(ch)(an)/ij
-    - derive/(sh)(an)/uj
-    - derive/(zh)(an)/vj
+    - derive/^([bcdfghklmnprstwyz])(an)$/$1j
+    - derive/^(ch)(an)$/ij
+    - derive/^(sh)(an)$/uj
+    - derive/^(zh)(an)$/vj
 
       # 单字母韵母
-    - derive/a/aa
-    - derive/o/oo
-    - derive/e/ee
+    - derive/^(a)$/aa
+    - derive/^(o)$/oo
+    - derive/^(e)$/ee
 
       # 三字母韵母
-    - derive/ang/ah
-    - derive/eng/eg
+    - derive/^(ang)$/ah
+    - derive/^(eng)$/eg
 
       # 卷舌声母
-    - derive/zh([aeiu])/v$1
-    - derive/ch([aeiu])/i$1
-    - derive/sh([aeiu])/u$1
+    - derive/^(zh)([aeiu])$/v$2
+    - derive/^(ch)([aeiu])$/i$2
+    - derive/^(sh)([aeiu])$/u$2
 
       # 四字母韵母
-    - derive/([jlnqx])(iang)/$1l
-    - derive/([jqx])(iong)/$1s
+    - derive/^([jlnqx])(iang)$/$1l
+    - derive/^([jqx])(iong)$/$1s
 
       # 三字母韵母
-    - derive/([bdjlmnpqtxy])(ing)/$1k
-    - derive/([bdjlmnpqtx])(iao)/$1n
-    - derive/([bdjlmnpqtx])(ian)/$1m
+    - derive/^([bdjlmnpqtxy])(ing)$/$1k
+    - derive/^([bdjlmnpqtx])(iao)$/$1n
+    - derive/^([bdjlmnpqtx])(ian)$/$1m
 
       # 二字母韵母
-    - derive/([djlmnqx])(iu)/$1q
-    - derive/([jlnqxy])[uv]e/$1t
-    - derive/([bdjlmnpqtx])(ie)/$1p
-    - derive/([djlqx])(ia)/$1x
-    - derive/([bjlmnpqxy])(in)/$1b
+    - derive/^([djlmnqx])(iu)$/$1q
+    - derive/^([jlnqxy])[uv]e/$1t
+    - derive/^([bdjlmnpqtx])(ie)$/$1p
+    - derive/^([djlqx])(ia)$/$1x
+    - derive/^([bjlmnpqxy])(in)$/$1b
 
       # iuv特殊处理
       # 四字母
-    - derive/([ghk])(uang)/$1l
-    - derive/(ch)(uang)/il
-    - derive/(sh)(uang)/ul
-    - derive/(zh)(uang)/vl
+    - derive/^([ghk])(uang)$/$1l
+    - derive/^(ch)(uang)$/il
+    - derive/^(sh)(uang)$/ul
+    - derive/^(zh)(uang)$/vl
 
       # 三字母
-    - derive/([cdghjklnqrstxyz])(uan)/$1r
-    - derive/(ch)(uan)/ir
-    - derive/(sh)(uan)/ur
-    - derive/(zh)(uan)/vr
+    - derive/^([cdghjklnqrstxyz])(uan)$/$1r
+    - derive/^(ch)(uan)$/ir
+    - derive/^(sh)(uan)$/ur
+    - derive/^(zh)(uan)$/vr
 
-    - derive/([bcdfghklmnprstwz])(eng)/$1g
-    - derive/(ch)(eng)/ig
-    - derive/(sh)(eng)/ug
-    - derive/(zh)(eng)/vg
+    - derive/^([bcdfghklmnprstwz])(eng)$/$1g
+    - derive/^(ch)(eng)$/ig
+    - derive/^(sh)(eng)$/ug
+    - derive/^(zh)(eng)$/vg
 
-    - derive/([ghk])(uai)/$1k
-    - derive/(ch)(uai)/ik
-    - derive/(sh)(uai)/uk
-    - derive/(zh)(uai)/vk
+    - derive/^([ghk])(uai)$/$1k
+    - derive/^(ch)(uai)$/ik
+    - derive/^(sh)(uai)$/uk
+    - derive/^(zh)(uai)$/vk
 
       # 二字母
-    - derive/([bdfghklmnpwz])(ei)/$1w
-    - derive/(sh)(ei)/uh
-    - derive/(zh)(ei)/vh
+    - derive/^([bdfghklmnpwz])(ei)$/$1w
+    - derive/^(sh)(ei)$/uw
+    - derive/^(zh)(ei)$/vw
 
-    - derive/([cdghjklqrstxyz])(un)/$1y
-    - derive/(ch)(un)/iy
-    - derive/(sh)(un)/uy
-    - derive/(zh)(un)/vy
+    - derive/^([cdghjklqrstxyz])(un)$/$1y
+    - derive/^(ch)(un)$/iy
+    - derive/^(sh)(un)$/uy
+    - derive/^(zh)(un)$/vy
 
-    - derive/([cdghklnrstz])(uo)/$1o
-    - derive/(ch)(uo)/io
-    - derive/(sh)(uo)/uo
-    - derive/(zh)(uo)/vo
+    - derive/^([cdghklnrstz])(uo)$/$1o
+    - derive/^(ch)(uo)$/io
+    - derive/^(sh)(uo)$/uo
+    - derive/^(zh)(uo)$/vo
 
-    - derive/([bcdfghkmnprswz])(en)/$1f
-    - derive/(ch)(en)/if
-    - derive/(sh)(en)/uf
-    - derive/(zh)(en)/vf
+    - derive/^([bcdfghkmnprswz])(en)$/$1f
+    - derive/^(ch)(en)$/if
+    - derive/^(sh)(en)$/uf
+    - derive/^(zh)(en)$/vf
 
-    - derive/([cdfghklmnprstyz])(ou)/$1z
-    - derive/(ch)(ou)/iz
-    - derive/(sh)(ou)/uz
-    - derive/(zh)(ou)/vz
+    - derive/^([cdfghklmnprstyz])(ou)$/$1z
+    - derive/^(ch)(ou)$/iz
+    - derive/^(sh)(ou)$/uz
+    - derive/^(zh)(ou)$/vz
 
-    - derive/([ghkr])(ua)/$1x
-    - derive/(ch)(ua)/ix
-    - derive/(sh)(ua)/ux
-    - derive/(zh)(ua)/vx
+    - derive/^([ghkr])(ua)$/$1x
+    - derive/^(ch)(ua)$/ix
+    - derive/^(sh)(ua)$/ux
+    - derive/^(zh)(ua)$/vx
 
-    - derive/([cdghkrstz])(ui)/$1v
-    - derive/(ch)(ui)/iv
-    - derive/(sh)(ui)/uv
-    - derive/(zh)(ui)/vv
+    - derive/^([cdghkrstz])(ui)$/$1v
+    - derive/^(ch)(ui)$/iv
+    - derive/^(sh)(ui)$/uv
+    - derive/^(zh)(ui)$/vv
 
 wubi98_mint:
   tag: wubi98_mint


### PR DESCRIPTION
fixes: 张居正-修复形如“rfg”识别为“reng”的问题
fixes: 张居正-将“shei”"zhei"的键入码更正为“uw”"vw"