### PR TITLE
fix: 让小鹤音形支持分号直接上屏

### DIFF
--- a/double_pinyin_flypy.schema.yaml
+++ b/double_pinyin_flypy.schema.yaml
@@ -241,7 +241,9 @@ cn_en:
 # 拼写设定
 speller:
   # 如果不想让什么标点直接上屏，可以加在 alphabet，或者编辑标点符号为两个及以上的映射
-  alphabet: zyxwvutsrqponmlkjihgfedcbaZYXWVUTSRQPONMLKJIHGFEDCBA~;
+  alphabet: zyxwvutsrqponmlkjihgfedcbaZYXWVUTSRQPONMLKJIHGFEDCBA;
+  # initials 定义仅作为始码的按键，排除 ; 让单个的 ; 可以直接上屏
+  initials: zyxwvutsrqponmlkjihgfedcbaZYXWVUTSRQPONMLKJIHGFEDCBA
   delimiter: " `"  # 第一位<空格>是拼音之间的分隔符；第二位<'>表示可以手动输入单引号来分割拼音。
   algebra:
     - erase/^xx$/


### PR DESCRIPTION
主要有两个改动，

1. `speller.alphabet` 中去掉了 `~`，这个按键以前作为反查前缀，但已在 <https://github.com/Mintimate/oh-my-rime/commit/51779acb88a447926af451426439573d504638f7> 中被移除
2. 添加 `speller.initials`，这让分号 `;` 作为辅码激活键的同时，也能直接作为标点符号输入，而不必每次都弹出一个无用的候选框

二者均在 Linux (ibus-rime) 和 Android (fcitx5-android) 测试过，没发现其它副作用．

另外，对于第二点改动，之前有人提过 <https://github.com/Mintimate/oh-my-rime/issues/152>，看讨论好像是故意而为之？但我感觉这样好像没有必要，反而是降低了输入体验．

不过，如果要保持现状也没关系，这个 PR 可以关闭，仅为有相关需求的同学提供一个解决方案 ~(^ω^)
