### PR TITLE
feat: 输入的拼音<=候选词的注音时，该候选词不显示注音

### DIFF
--- a/lua/corrector_filter.lua
+++ b/lua/corrector_filter.lua
@@ -165,7 +165,6 @@ function M.func(input, env)
                     -- 输入的拼音<=候选词的注音时，该候选词不显示注音
                     if M.is_pure_pinyin then
                         local normal_pinyin = normalize_pinyin(pinyin)
-                        log.error("normal_pinyin".. tostring(normal_pinyin))
                         if #normal_pinyin <= input_len and normal_pinyin.find(input_str, normal_pinyin) then
                             cand:get_genuine().comment = ""
                         else


### PR DESCRIPTION
tone_display打开时，输入的拼音<=候选词的注音时，该候选词不显示注音
输入：women
候选字：我们、我、握等等 都不再显示注音，因为都是women这个音的子集下的；而 我萌 womeng、我盟如果是候选字，显示注音